### PR TITLE
Add looping hero background video

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,11 +1,521 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="pt-BR">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Teste Github-Site</title>
+    <title>Lumen Shows Católicos</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Playfair+Display:wght@600;700&display=swap" rel="stylesheet">
+    <style>
+        :root {
+            --bg: #0f172a;
+            --surface: #111c3a;
+            --card: #182447;
+            --primary: #f6c453;
+            --accent: #7dd3fc;
+            --text: #f8fafc;
+            --muted: #cbd5f5;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: "Inter", sans-serif;
+            background: radial-gradient(circle at top, #1e293b 0%, #0f172a 45%, #0b1122 100%);
+            color: var(--text);
+            line-height: 1.6;
+        }
+
+        a {
+            color: inherit;
+            text-decoration: none;
+        }
+
+        .container {
+            width: min(1200px, 90%);
+            margin: 0 auto;
+        }
+
+        header {
+            padding: 24px 0;
+            position: sticky;
+            top: 0;
+            backdrop-filter: blur(18px);
+            background: rgba(15, 23, 42, 0.75);
+            border-bottom: 1px solid rgba(148, 163, 184, 0.2);
+            z-index: 10;
+        }
+
+        .nav {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+        }
+
+        .logo {
+            font-family: "Playfair Display", serif;
+            font-weight: 700;
+            font-size: 1.5rem;
+            letter-spacing: 0.5px;
+            color: var(--primary);
+        }
+
+        .nav-links {
+            display: flex;
+            gap: 24px;
+            font-weight: 500;
+            color: var(--muted);
+        }
+
+        .cta {
+            padding: 12px 22px;
+            border-radius: 999px;
+            background: var(--primary);
+            color: #1f2937;
+            font-weight: 600;
+            box-shadow: 0 12px 24px rgba(246, 196, 83, 0.25);
+        }
+
+        .hero {
+            position: relative;
+            padding: 80px 0 60px;
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+            gap: 48px;
+            align-items: center;
+            min-height: 520px;
+            overflow: hidden;
+            border-radius: 32px;
+        }
+
+        .hero-bg {
+            position: absolute;
+            inset: 0;
+            z-index: 0;
+            overflow: hidden;
+            border-radius: 32px;
+        }
+
+        .hero-bg video {
+            width: 100%;
+            height: 100%;
+            object-fit: cover;
+            filter: brightness(0.45);
+        }
+
+        .hero-bg::after {
+            content: "";
+            position: absolute;
+            inset: 0;
+            background: linear-gradient(90deg, rgba(15, 23, 42, 0.92) 0%, rgba(15, 23, 42, 0.6) 55%, rgba(15, 23, 42, 0.3) 100%);
+        }
+
+        .hero-content,
+        .hero-card {
+            position: relative;
+            z-index: 1;
+        }
+
+        .hero h1 {
+            font-family: "Playfair Display", serif;
+            font-size: clamp(2.5rem, 3.6vw, 3.8rem);
+            margin-bottom: 16px;
+        }
+
+        .hero p {
+            color: var(--muted);
+            font-size: 1.1rem;
+            margin-bottom: 28px;
+        }
+
+        .hero-actions {
+            display: flex;
+            gap: 16px;
+            flex-wrap: wrap;
+        }
+
+        .ghost {
+            padding: 12px 22px;
+            border-radius: 999px;
+            border: 1px solid rgba(248, 250, 252, 0.3);
+            color: var(--text);
+        }
+
+        .hero-card {
+            background: linear-gradient(160deg, rgba(125, 211, 252, 0.2), rgba(255, 255, 255, 0));
+            border: 1px solid rgba(125, 211, 252, 0.35);
+            border-radius: 24px;
+            padding: 28px;
+            display: grid;
+            gap: 18px;
+        }
+
+        .hero-card span {
+            color: var(--accent);
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 1px;
+            font-size: 0.75rem;
+        }
+
+        .hero-card h3 {
+            font-size: 1.5rem;
+        }
+
+        .stats {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+            gap: 18px;
+            margin-top: 24px;
+        }
+
+        .stat {
+            background: var(--card);
+            padding: 16px 18px;
+            border-radius: 18px;
+            border: 1px solid rgba(148, 163, 184, 0.2);
+        }
+
+        .stat strong {
+            font-size: 1.3rem;
+            display: block;
+        }
+
+        section {
+            padding: 60px 0;
+        }
+
+        .section-title {
+            font-family: "Playfair Display", serif;
+            font-size: 2rem;
+            margin-bottom: 12px;
+        }
+
+        .section-subtitle {
+            color: var(--muted);
+            margin-bottom: 32px;
+        }
+
+        .grid {
+            display: grid;
+            gap: 22px;
+            grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+        }
+
+        .card {
+            background: var(--card);
+            padding: 24px;
+            border-radius: 20px;
+            border: 1px solid rgba(148, 163, 184, 0.2);
+            box-shadow: 0 20px 50px rgba(15, 23, 42, 0.35);
+        }
+
+        .card h4 {
+            margin-bottom: 8px;
+        }
+
+        .events {
+            display: grid;
+            gap: 20px;
+        }
+
+        .event {
+            background: var(--surface);
+            border-radius: 18px;
+            padding: 20px;
+            display: grid;
+            gap: 12px;
+            border: 1px solid rgba(148, 163, 184, 0.2);
+        }
+
+        .event strong {
+            font-size: 1.15rem;
+        }
+
+        .event-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 10px;
+            color: var(--muted);
+            font-size: 0.9rem;
+        }
+
+        .event button {
+            align-self: flex-start;
+            padding: 10px 18px;
+            border-radius: 999px;
+            border: none;
+            background: var(--accent);
+            color: #0f172a;
+            font-weight: 600;
+            cursor: pointer;
+        }
+
+        .pricing {
+            display: grid;
+            gap: 20px;
+            grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+        }
+
+        .price-card {
+            background: linear-gradient(160deg, rgba(246, 196, 83, 0.15), rgba(255, 255, 255, 0));
+            border-radius: 22px;
+            padding: 28px;
+            border: 1px solid rgba(246, 196, 83, 0.3);
+        }
+
+        .price-card h3 {
+            margin-bottom: 8px;
+        }
+
+        .price {
+            font-size: 2rem;
+            font-weight: 700;
+            margin: 12px 0;
+        }
+
+        .price-card ul {
+            list-style: none;
+            display: grid;
+            gap: 10px;
+            color: var(--muted);
+        }
+
+        .price-card button {
+            margin-top: 18px;
+            width: 100%;
+            padding: 12px 20px;
+            border-radius: 999px;
+            border: none;
+            background: var(--primary);
+            color: #1f2937;
+            font-weight: 600;
+            cursor: pointer;
+        }
+
+        .cta-band {
+            background: linear-gradient(120deg, rgba(125, 211, 252, 0.15), rgba(246, 196, 83, 0.1));
+            border-radius: 26px;
+            padding: 36px;
+            text-align: center;
+            border: 1px solid rgba(125, 211, 252, 0.35);
+        }
+
+        footer {
+            padding: 40px 0 60px;
+            color: var(--muted);
+            border-top: 1px solid rgba(148, 163, 184, 0.2);
+        }
+
+        .footer-grid {
+            display: grid;
+            gap: 20px;
+            grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+        }
+
+        .badge {
+            display: inline-flex;
+            align-items: center;
+            gap: 8px;
+            padding: 6px 14px;
+            border-radius: 999px;
+            background: rgba(248, 250, 252, 0.08);
+            color: var(--muted);
+            font-size: 0.85rem;
+        }
+
+        @media (max-width: 720px) {
+            .nav-links {
+                display: none;
+            }
+        }
+    </style>
 </head>
 <body>
-    <p>Este é um Teste</p>
+    <header>
+        <div class="container nav">
+            <div class="logo">Lumen</div>
+            <nav class="nav-links">
+                <a href="#diferenciais">Diferenciais</a>
+                <a href="#agenda">Agenda</a>
+                <a href="#planos">Planos</a>
+                <a href="#contato">Contato</a>
+            </nav>
+            <a class="cta" href="#agenda">Garantir ingresso</a>
+        </div>
+    </header>
+
+    <main class="container">
+        <section class="hero">
+            <div class="hero-bg" aria-hidden="true">
+                <video autoplay loop muted playsinline poster="https://images.unsplash.com/photo-1497032628192-86f99bcd76bc?auto=format&fit=crop&w=1600&q=80">
+                    <source src="https://cdn.coverr.co/videos/coverr-concert-stage-lights-7074/1080p.mp4" type="video/mp4">
+                </video>
+            </div>
+            <div class="hero-content">
+                <span class="badge">Shows católicos com propósito</span>
+                <h1>Venda de ingressos premium para experiências de fé e música.</h1>
+                <p>Conectamos paróquias, comunidades e ministérios com turnês católicas inspiradoras. Plataforma segura, bilheteria digital e suporte pastoral completo.</p>
+                <div class="hero-actions">
+                    <a class="cta" href="#planos">Quero vender agora</a>
+                    <a class="ghost" href="#diferenciais">Conheça a plataforma</a>
+                </div>
+                <div class="stats">
+                    <div class="stat">
+                        <strong>120 mil+</strong>
+                        Fiéis impactados
+                    </div>
+                    <div class="stat">
+                        <strong>86%</strong>
+                        Ocupação média
+                    </div>
+                    <div class="stat">
+                        <strong>24h</strong>
+                        Suporte dedicado
+                    </div>
+                </div>
+            </div>
+            <div class="hero-card">
+                <span>Turnê em destaque</span>
+                <h3>Cantos de Luz - 2024</h3>
+                <p>Uma jornada musical com orações, testemunhos e repertório mariano. Ative vendas antecipadas e pacotes para grupos.</p>
+                <div class="event-meta">
+                    <span>📍 São Paulo • Rio • BH</span>
+                    <span>📅 Julho a Setembro</span>
+                </div>
+                <a class="cta" href="#agenda">Ver datas</a>
+            </div>
+        </section>
+
+        <section id="diferenciais">
+            <h2 class="section-title">Tudo o que seu show precisa para lotar</h2>
+            <p class="section-subtitle">Ferramentas para evangelizar com excelência e gerar resultados financeiros sustentáveis.</p>
+            <div class="grid">
+                <div class="card">
+                    <h4>Bilheteria digital integrada</h4>
+                    <p>Checkout rápido, QR Code e área exclusiva para caravanas e grupos pastorais.</p>
+                </div>
+                <div class="card">
+                    <h4>Gestão de equipes</h4>
+                    <p>Escalas de voluntários, credenciamento e relatórios de presença em tempo real.</p>
+                </div>
+                <div class="card">
+                    <h4>Campanhas segmentadas</h4>
+                    <p>Envio de convites por região, faixas etárias e histórico de participação.</p>
+                </div>
+                <div class="card">
+                    <h4>Experiência espiritual</h4>
+                    <p>Materiais catequéticos, roteiro litúrgico e apoio de missionários convidados.</p>
+                </div>
+            </div>
+        </section>
+
+        <section id="agenda">
+            <h2 class="section-title">Agenda aberta para reservas</h2>
+            <p class="section-subtitle">Selecione a cidade e bloqueie os melhores lugares para seu público.</p>
+            <div class="events">
+                <div class="event">
+                    <strong>Noite da Misericórdia</strong>
+                    <div class="event-meta">
+                        <span>📍 Curitiba, PR</span>
+                        <span>📅 14 de Agosto</span>
+                        <span>⏰ 19h30</span>
+                    </div>
+                    <button>Reservar ingressos</button>
+                </div>
+                <div class="event">
+                    <strong>Vozes do Céu</strong>
+                    <div class="event-meta">
+                        <span>📍 Fortaleza, CE</span>
+                        <span>📅 02 de Setembro</span>
+                        <span>⏰ 20h</span>
+                    </div>
+                    <button>Reservar ingressos</button>
+                </div>
+                <div class="event">
+                    <strong>Coração Eucarístico</strong>
+                    <div class="event-meta">
+                        <span>📍 Belo Horizonte, MG</span>
+                        <span>📅 28 de Setembro</span>
+                        <span>⏰ 18h</span>
+                    </div>
+                    <button>Reservar ingressos</button>
+                </div>
+            </div>
+        </section>
+
+        <section id="planos">
+            <h2 class="section-title">Planos flexíveis para cada comunidade</h2>
+            <p class="section-subtitle">Combine recursos digitais e assessoria presencial conforme o porte do evento.</p>
+            <div class="pricing">
+                <div class="price-card">
+                    <h3>Essencial</h3>
+                    <p class="price">8% receita</p>
+                    <ul>
+                        <li>Bilheteria digital + QR Code</li>
+                        <li>Checkout com Pix e cartão</li>
+                        <li>Relatórios automáticos</li>
+                    </ul>
+                    <button>Começar agora</button>
+                </div>
+                <div class="price-card">
+                    <h3>Missionário</h3>
+                    <p class="price">12% receita</p>
+                    <ul>
+                        <li>Gestão de caravanas</li>
+                        <li>Equipe presencial no dia</li>
+                        <li>Campanhas segmentadas</li>
+                    </ul>
+                    <button>Falar com consultor</button>
+                </div>
+                <div class="price-card">
+                    <h3>Turnê Nacional</h3>
+                    <p class="price">Sob consulta</p>
+                    <ul>
+                        <li>Estratégia completa de vendas</li>
+                        <li>Produção artística e palco</li>
+                        <li>Rede de parceiros católicos</li>
+                    </ul>
+                    <button>Solicitar proposta</button>
+                </div>
+            </div>
+        </section>
+
+        <section>
+            <div class="cta-band">
+                <h2 class="section-title">Prepare a próxima experiência de fé</h2>
+                <p class="section-subtitle">Vamos caminhar com sua comunidade para levar música e evangelização a milhares de corações.</p>
+                <a class="cta" href="#contato">Agendar reunião</a>
+            </div>
+        </section>
+    </main>
+
+    <footer id="contato">
+        <div class="container footer-grid">
+            <div>
+                <div class="logo">Lumen</div>
+                <p>Plataforma completa para vendas de shows católicos, com foco em excelência e missão.</p>
+            </div>
+            <div>
+                <h4>Contato</h4>
+                <p>contato@lumen.com.br</p>
+                <p>(11) 99999-0000</p>
+            </div>
+            <div>
+                <h4>Endereço</h4>
+                <p>Av. das Nações, 1200</p>
+                <p>São Paulo - SP</p>
+            </div>
+            <div>
+                <h4>Redes sociais</h4>
+                <p>Instagram · YouTube · Spotify</p>
+            </div>
+        </div>
+    </footer>
 </body>
 </html>


### PR DESCRIPTION
### Motivation
- Address the inline request to have a looping video background in the hero to improve visual impact and match the desired design. 
- Keep hero content legible and accessible by adding overlay and layering so CTAs and copy remain readable over motion. 
- Provide a framework-agnostic static change that can be integrated into existing landing page assets and later hooked to backend ticketing logic. 

### Description
- Updated `index.html` markup to add a `.hero-bg` container with a `<video autoplay loop muted playsinline poster>` element sourcing a concert video for the hero background. 
- Added CSS to position the hero as `relative`, make `.hero-bg` `absolute`/`inset: 0`, and style the video with `object-fit: cover`, `filter: brightness(0.45)` and a gradient overlay via `.hero-bg::after`. 
- Ensured content stacking by applying `z-index: 1` to `.hero-content` and `.hero-card`, added `min-height`, `overflow: hidden`, and `border-radius` to the hero for consistent visual layout. 
- Also included locale and typography updates by setting `lang=

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983aa092668832da83821b336e58003)